### PR TITLE
filter out 0 size venn set while keeping element size

### DIFF
--- a/src/venn-diagram.component.ts
+++ b/src/venn-diagram.component.ts
@@ -33,6 +33,10 @@ export class VennDiagramComponent implements OnDestroy, OnChanges {
   }
 
   ngOnChanges() {
+    this.elementRef.nativeElement.style.width = `${this.svgSquareDimension}px`;
+    this.elementRef.nativeElement.style.height = `${this.svgSquareDimension}px`;
+    this.elementRef.nativeElement.style.display = 'block';
+    this.vennSets = this.vennSets.filter(vennSet => vennSet.size);
     if (this.vennSets.length > 0) {
       if (this.div) {
         this.tooltip.remove();


### PR DESCRIPTION
@CINBCUniversal/suprematism 

In addition to being [more judicious](https://github.com/NBCUAS/audri/pull/153) in hitting the api, this is a fix for a different aspect of Stella's [7 expressions bug](https://jira.inbcu.com/browse/AUG-395), audience 7E_test21. In the seven expressions, there are two with a reach of 0 (expressions 5 and 6 in the screenshot).

This PR filters out any 0 size venn set objects. 
If all the objects in `vennSets` are chartable data (each venn set size is greater than 0), nothing changes.
If a venn set object has 0 size, it is removed, and the rest of the venn set objects are charted.
If all the objects in `vennSets` are 0 size, then no chart is rendered. Spacing is accounted for on the host element.

The crosstab diagram now looks like this
<img width="1352" alt="screen shot 2017-05-04 at 3 12 39 pm" src="https://cloud.githubusercontent.com/assets/6545515/25721741/8bbe17c8-30df-11e7-93b5-71006ed9ecc4.png">
